### PR TITLE
build: kexec: clean only when Makefile exist

### DIFF
--- a/build/build_kexec.sh
+++ b/build/build_kexec.sh
@@ -19,7 +19,9 @@ function build_kexec {
 
     export CROSS_COMPILE=aarch64-linux-musl-
 
-    [[ "${clean}" == true ]] && make clean
+    if [[ "${clean}" == true ]] && [ -f Makefile ]; then
+        make clean
+    fi
 
     [ ! -f configure ] && ./bootstrap
 


### PR DESCRIPTION
The clean target can be executed only if the Makefile has already been generated.