### PR TITLE
Fix: Stop boot with any key press

### DIFF
--- a/kbootd/src/main.c
+++ b/kbootd/src/main.c
@@ -101,7 +101,7 @@ int main(void)
 
         ret = fastboot_init();
         if (ret == -1) {
-                log("fasboot init failed\n");
+                log("fastboot init failed\n");
                 return ret;
         }
 


### PR DESCRIPTION
Although console message indicated that any key could be pressed to
stop boot, only by pressing Enter the boot stopped and we could enter
on kboot shell.

This happens because terminal is configured in canonical mode by default,
meaning that input is made available line by line, when one of the line
delimiters is typed. To be able to receive each typed character, one by
one, change terminal configuration before managing stop boot.

Also: fix typo