### PR TITLE
kbootd: fix overflow when reading gpt header

### DIFF
--- a/kbootd/src/main.c
+++ b/kbootd/src/main.c
@@ -68,17 +68,17 @@ static bool prompt_stop_boot(void)
 
 static void set_terminal_single_char_read(void)
 {
-	struct termios local_term_attributes;
+        struct termios local_term_attributes;
 
-	if (!isatty(STDIN_FILENO))
-		return;
-	if (tcgetattr(STDIN_FILENO, &local_term_attributes))
-		return;
+        if (!isatty(STDIN_FILENO))
+                return;
+        if (tcgetattr(STDIN_FILENO, &local_term_attributes))
+                return;
 
-	local_term_attributes.c_lflag &= ~(ICANON | ECHO);
-	local_term_attributes.c_cc[VMIN] = 1;
-	local_term_attributes.c_cc[VTIME] = 0;
-	tcsetattr(STDIN_FILENO, TCSANOW, &local_term_attributes);
+        local_term_attributes.c_lflag &= ~(ICANON | ECHO);
+        local_term_attributes.c_cc[VMIN] = 1;
+        local_term_attributes.c_cc[VTIME] = 0;
+        tcsetattr(STDIN_FILENO, TCSANOW, &local_term_attributes);
 }
 
 static bool stop_boot(void)
@@ -91,7 +91,7 @@ static bool stop_boot(void)
                 return stop;
         }
 
-	set_terminal_single_char_read();
+        set_terminal_single_char_read();
 
         stop = prompt_stop_boot();
         if (stop)

--- a/kbootd/src/part.c
+++ b/kbootd/src/part.c
@@ -327,7 +327,7 @@ static void gpt_convert_efi_name_to_char(char *s, void *es, int n)
 static int find_gpt_entry(int fd, const char *name, struct gpt_entry *gpt_e,
                           off_t *offset)
 {
-        struct gpt_header gpt_hdr;
+        struct gpt_header *gpt_hdr;
         char part[PARTNAME_SZ];
         char data[LBA_SIZE];
         int ret;
@@ -339,13 +339,16 @@ static int find_gpt_entry(int fd, const char *name, struct gpt_entry *gpt_e,
                 return ret;
         }
 
-        ret = kread(fd, (char *)&gpt_hdr, LBA_SIZE);
+        memset(data, '\0', LBA_SIZE);
+        ret = kread(fd, data, LBA_SIZE);
         if (ret == -1) {
                 log("read GPT header failed\n");
                 return -1;
         }
+        gpt_hdr = (struct gpt_header *)data;
 
-        for (int i = 0; i < gpt_hdr.n_parts; i++) {
+        for (int i = 0; i < gpt_hdr->n_parts; i++) {
+                memset(data, '\0', LBA_SIZE);
                 ret = kread(fd, data, LBA_SIZE);
                 if (ret == -1) {
                         log("read GPT entry failed\n");


### PR DESCRIPTION
When we read GPT header on LBA 1 we must use data allocated with a size of LBA_SIZE.

Otherwise we may have an overflow.